### PR TITLE
Fix several issues with the flow-libdef

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -8,52 +8,50 @@ Custom input types are encoded in exactly the same way the Default input types a
 
 ## Type Definition
 
-Recall that the plugin input types are passed into `mods`, as a property called `customFormInputs`,into the `FormBuilder` (see [Usage](Usage.md)):
+Flow type defintions are available via [flow-typed](https://github.com/flow-typed/flow-typed).
+
+Recall that the plugin input types are passed into `mods`, as a property called `customFormInputs`,into the `FormBuilder` (see [Usage](Usage.md)). The type definition is as follows:
 
 ```react
-export type Mods = {
+declare type Mods = {|
   customFormInputs?: {
-    [string]: FormInput
+    [string]: FormInput,
+    ...
   },
-  tooltipDescriptions?: {
+  tooltipDescriptions?: {|
     add?: string,
     cardObjectName?: string,
     cardDisplayName?: string,
     cardDescription?: string,
-    cardInputType?: string
-  }
-}
+    cardInputType?: string,
+  |},
+|};
 ```
 
 A single `FormInput` has a type definition as follows:
 
 ```react
-export type FormInput = {
+declare type FormInput = {|
   displayName: string,
   // given a data and ui schema, determine if the object is of this input type
   matchIf: Array<MatchType>,
   // allowed keys for ui:options
   possibleOptions?: Array<string>,
   defaultDataSchema: {
-    [string]: any
+    [string]: any,
+    ...
   },
   defaultUiSchema: {
-    [string]: any
+    [string]: any,
+    ...
   },
   // the data schema type
   type: DataType,
   // inputs on the preview card
-  cardBody: React.AbstractComponent<{
-    parameters: Parameters,
-    onChange: (newParams: Parameters) => void,
-    mods: { [string]: any }
-  }>,
+  cardBody: React$ComponentType<CardBodyProps>,
   // inputs for the modal
-  modalBody?: React.AbstractComponent<{
-    parameters: Parameters,
-    onChange: (newParams: Parameters) => void
-  }>
-}
+  modalBody?: React$ComponentType<CardBodyProps>,
+  |};
 ```
 
 The `displayName` is the full name of the desired form input. For example, **Short Answer** is the `displayName` for the `shortAnswer` form input. 
@@ -68,15 +66,15 @@ The `displayName` is the full name of the desired form input. For example, **Sho
 
 `type` is the Data Schema type that this input type defaults to. While a custom form input can have multiple types (would need to be defined in the `matchIf` array), this refers to the type that gets assigned immediately after a user selects this input type in the dropdown. The possible `DataType` options supported by `react-jsonschema-form` are as follows:
 
-```typescript
-type DataType =
+```react
+declare type DataType =
   | 'string'
   | 'number'
   | 'boolean'
   | 'integer'
   | 'array'
   | '*'
-  | null
+  | null;
 ```
 
 `cardBody` refers to a React component that gets rendered in the card itself, when expanded. This React component gets a set of `Parameters` that provide additional information about the FormInput, such as the `title` or the `default` properties. For more information, see the *Parameters* section.
@@ -87,16 +85,15 @@ type DataType =
 
 The `matchIf` array in a `FormInput` contains a series of `MatchType` objects, which represent different possible 'scenarios' that the `FormBuilder` may encounter when parsing a set of Data and UI Schema. The `MatchType` is defined as follows:
 
-```typescript
-type MatchType = {
+```react
+declare type MatchType = {|
   types: Array<DataType>,
   widget?: string,
   field?: string,
-  option?: { [string]: any },
   format?: string,
   $ref?: boolean,
-  enum?: boolean
-}
+  enum?: boolean,
+|};
 ```
 
 `types` refers to the set of possible input types that can register in a particular scenario.
@@ -111,20 +108,29 @@ type MatchType = {
 
 `enum` is a boolean that evaluates to true if the component has a property `enum` in the Data Schema.
 
-## Parameters
+## Component Types
 
-The following is a type definition for the Parameters object:
+`cardBody` and `modalBody` are components whose props have a type of `CardBodyProps`:
 
 ```react
-export type Parameters = {
+declare export type CardBodyProps = {|
+  parameters: Parameters,
+  onChange: (newParams: Parameters) => void,
+|};
+```
+
+`Parameters` is defined as:
+
+```react
+declare type Parameters = {|
   [string]: string | number | boolean | Array<string | number>,
   name: string,
   path: string,
-  definitionData: { [string]: any },
-  definitionUi: { [string]: any },
+  definitionData: { [string]: any, ... },
+  definitionUi: { [string]: any, ... },
   category: string,
-  'ui:option': { [string]: any }
-}
+  'ui:option': { [string]: any, ... },
+|};
 ```
 
 It can hold any number of keys pointing to specific values. One common example is `parameters.default`, which stores the default value specified by the builder for this `FormInput`.

--- a/flow-libdef/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.92.x-/react-json-schema-form-builder_v1.x.x.js
+++ b/flow-libdef/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.92.x-/react-json-schema-form-builder_v1.x.x.js
@@ -1,45 +1,17 @@
 declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
-  declare type CardProps = {|
-    name: string,
-    required: boolean,
-    dataOptions: {| [string]: any |},
-    uiOptions: {| [string]: any |},
-    $ref?: string,
-    dependents?: Array<{|
-      children: Array<string>,
-      value?: any,
-    |}>,
-    dependent?: boolean,
-    parent?: string,
-    propType: string,
-    neighborNames: Array<string>,
-  |};
-
-  declare type SectionProps = {|
-    name: string,
-    required: boolean,
-    schema: {| [string]: any |},
-    uischema: {| [string]: any |},
-    $ref?: string,
-    dependents?: Array<{|
-      children: Array<string>,
-      value?: any,
-    |}>,
-    dependent?: boolean,
-    propType: string,
-    neighborNames: Array<string>,
-  |};
-
-  declare type ElementProps = CardProps & SectionProps;
-
   declare type Parameters = {|
     [string]: string | number | boolean | Array<string | number>,
     name: string,
     path: string,
-    definitionData: {| [string]: any |},
-    definitionUi: {| [string]: any |},
+    definitionData: { [string]: any, ... },
+    definitionUi: { [string]: any, ... },
     category: string,
-    'ui:option': {| [string]: any |},
+    'ui:option': { [string]: any, ... },
+  |};
+
+  declare export type CardBodyProps = {|
+    parameters: Parameters,
+    onChange: (newParams: Parameters) => void,
   |};
 
   declare type DataType =
@@ -66,32 +38,28 @@ declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
     matchIf: Array<MatchType>,
     // allowed keys for ui:options
     possibleOptions?: Array<string>,
-    defaultDataSchema: {|
+    defaultDataSchema: {
       [string]: any,
-    |},
-    defaultUiSchema: {|
+      ...
+    },
+    defaultUiSchema: {
       [string]: any,
-    |},
+      ...
+    },
     // the data schema type
     type: DataType,
     // inputs on the preview card
-    cardBody: React$AbstractComponent<{|
-      parameters: Parameters,
-      onChange: (newParams: Parameters) => void,
-      mods: {| [string]: any |},
-    |}>,
+    cardBody: React$ComponentType<CardBodyProps>,
     // inputs for the modal
-    modalBody?: React$AbstractComponent<{|
-      parameters: Parameters,
-      onChange: (newParams: Parameters) => void,
-    |}>,
+    modalBody?: React$ComponentType<CardBodyProps>,
   |};
 
   // optional properties that can add custom features to the form builder
   declare type Mods = {|
-    customFormInputs?: {|
+    customFormInputs?: {
       [string]: FormInput,
-    |},
+      ...
+    },
     tooltipDescriptions?: {|
       add?: string,
       cardObjectName?: string,

--- a/flow-libdef/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
+++ b/flow-libdef/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
@@ -5,6 +5,7 @@ import {
   FormBuilder,
   PredefinedGallery,
 } from '@ginkgo-bioworks/react-json-schema-form-builder';
+import type { CardBodyProps } from '@ginkgo-bioworks/react-json-schema-form-builder';
 import { it, describe } from 'flow-typed-test';
 
 describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
@@ -20,7 +21,54 @@ describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
     mods: {},
     className: 'foo'
   };
-
+  const propsWithMods = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+    mods: {
+      customFormInputs: {
+        customFormInput0: {
+          displayName: 'custom form input 0',
+          defaultDataSchema: {
+            'type': 'number',
+          },
+          defaultUiSchema: {
+            'ui:widget': 'customFormInput0',
+          },
+          type: 'number',
+          cardBody: (props: CardBodyProps) => <div/>,
+          modalBody: (props: CardBodyProps) => <div/>,
+          matchIf: [{
+            types: ['number'],
+            widget: 'customFormInput0',
+          }],
+        },
+        customFormInput1: {
+          displayName: 'custom form input 1',
+          defaultDataSchema: {
+            'type': 'string',
+          },
+          defaultUiSchema: {
+            'ui:field': 'customFormInput1',
+          },
+          type: 'string',
+          cardBody: (props: CardBodyProps) => <div/>,
+          modalBody: (props: CardBodyProps) => <div/>,
+          matchIf: [{
+            types: ['string'],
+            field: 'customFormInput1',
+          }],
+        },
+      },
+      tooltipDescriptions: {
+        add: 'add text',
+        cardObjectName: 'card object name text',
+        cardDisplayName: 'card display name text',
+        cardDescription: 'card description text',
+        cardInputType: 'card input type text',
+      },
+    },
+  };
   const extraneousProps = {
     schema: '',
     uischema: '',
@@ -46,6 +94,10 @@ describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
     <FormBuilder {...optionalProps} />
   });
 
+  it('render the form builder with props with mods', () => {
+    <FormBuilder {...propsWithMods} />
+  });
+
   it('form builder errors on extraneous properties passed in', () => {
     // $FlowExpectedError
     <FormBuilder {...extraneousProps} />
@@ -60,9 +112,13 @@ describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
     <PredefinedGallery {...props} />
   });
 
-  it('render predefined with optional props', () => {
+  it('render predefined gallery with optional props', () => {
     <PredefinedGallery {...optionalProps} />
   });
+
+  it('render predefined gallery with mods in props', () => {
+    <PredefinedGallery {...propsWithMods}/>
+  })
 
   it('predefined gallery errors on extraneous properties passed in', () => {
     // $FlowExpectedError


### PR DESCRIPTION
Fix several issues with the flow-libdef
- Remove `CardProps`, `SectionProps`, and `ElementProps`, which were vestigial and not currently being used.
- Remove exactness in object definitions with indexer properties, as they are incompatible.
- Export a props type for `cardBody` and `modalBody` components so that these components can be defined externally.
- Use `React$ComponentType`, as `React$AbstractComponent` was incorrect.