### PR TITLE
Upgrade devDependency react to 16.14.0

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@ginkgo-bioworks/react-json-schema-form-builder",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.6",
@@ -64,8 +64,8 @@
         "microbundle-crl": "^0.13.10",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.4",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
         "react-scripts": "^3.4.1",
         "rimraf": "^3.0.2"
       },
@@ -11995,10 +11995,10 @@
         "microbundle-crl": "^0.13.10",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.4",
-        "react": "^16.13.1",
+        "react": "^16.14.0",
         "react-beautiful-dnd": "^13.0.0",
         "react-bootstrap": "^1.3.0",
-        "react-dom": "^16.13.1",
+        "react-dom": "^16.14.0",
         "react-jss": "^10.4.0",
         "react-scripts": "^3.4.1",
         "react-select": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@ginkgo-bioworks/react-json-schema-form-builder",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.6",
@@ -45,8 +45,8 @@
         "microbundle-crl": "^0.13.10",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.4",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
         "react-scripts": "^3.4.1",
         "rimraf": "^3.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "microbundle-crl": "^0.13.10",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "react-scripts": "^3.4.1",
     "rimraf": "^3.0.2"
   },


### PR DESCRIPTION
Upgrade devDependency React of main library to 16.14.0. Also ensures that the example app and the main library refer to the same React.

Not upgrading to 17.0.1 because the example app has dependencies that are apparently not yet compatatible with React 17.

Hopefully this will resolve #19 by ensuring the parent and child modules refer to the same React.
Closes #19 