### PR TITLE
Allow users to add titles and descriptions for references

### DIFF
--- a/example/src/PlaygroundContainer.js
+++ b/example/src/PlaygroundContainer.js
@@ -18,11 +18,8 @@ const useStyles = createUseStyles({
   },
 });
 
-// Useful for setting up an initial schema for development purposes
-const initialJsonSchema = {};
-
 export default function PlaygroundContainer({ title }: { title: string }) {
-  const [schema, setSchema] = React.useState(JSON.stringify(initialJsonSchema));
+  const [schema, setSchema] = React.useState('{}');
   const [uischema, setUischema] = React.useState('{}');
   const classes = useStyles();
   return (

--- a/example/src/PlaygroundContainer.js
+++ b/example/src/PlaygroundContainer.js
@@ -19,15 +19,7 @@ const useStyles = createUseStyles({
 });
 
 // Useful for setting up an initial schema for development purposes
-const initialJsonSchema = {
-  definitions: {
-    address: {
-      type: 'string',
-      title: 'Default Address Title',
-      description: 'Default address description'
-    }
-  }
-}
+const initialJsonSchema = {};
 
 export default function PlaygroundContainer({ title }: { title: string }) {
   const [schema, setSchema] = React.useState(JSON.stringify(initialJsonSchema));

--- a/example/src/PlaygroundContainer.js
+++ b/example/src/PlaygroundContainer.js
@@ -18,8 +18,19 @@ const useStyles = createUseStyles({
   },
 });
 
+// Useful for setting up an initial schema for development purposes
+const initialJsonSchema = {
+  definitions: {
+    address: {
+      type: 'string',
+      title: 'Default Address Title',
+      description: 'Default address description'
+    }
+  }
+}
+
 export default function PlaygroundContainer({ title }: { title: string }) {
-  const [schema, setSchema] = React.useState('{}');
+  const [schema, setSchema] = React.useState(JSON.stringify(initialJsonSchema));
   const [uischema, setUischema] = React.useState('{}');
   const classes = useStyles();
   return (

--- a/src/formBuilder/CardGeneralParameterInputs.js
+++ b/src/formBuilder/CardGeneralParameterInputs.js
@@ -107,7 +107,6 @@ export default function CardGeneralParameterInputs({
             onChange({ ...parameters, title: ev.target.value });
           }}
           className='card-text'
-          readOnly={parameters.$ref !== undefined}
         />
       </div>
       <div className={`card-entry ${parameters.$ref ? 'disabled-input' : ''}`}>
@@ -136,7 +135,6 @@ export default function CardGeneralParameterInputs({
             onChange({ ...parameters, description: ev.target.value });
           }}
           className='card-text'
-          readOnly={parameters.$ref !== undefined}
         />
       </div>
       <div className='card-entry'>

--- a/src/formBuilder/FormBuilder.test.js
+++ b/src/formBuilder/FormBuilder.test.js
@@ -12,6 +12,28 @@ const props = {
   onChange: (newSchema, newUiSchema) => mockEvent(newSchema, newUiSchema),
 };
 
+const schemaWithDefinitions = {
+  type: 'object',
+  definitions: {
+    exampleDefinition: {
+      type: 'string',
+    },
+  },
+  properties: {
+    exampleField: {
+      $ref: '#/definitions/exampleDefinition',
+      title: 'Custom Title',
+      description: 'Custom Description',
+    },
+  },
+};
+
+const propsWithDefinitions = {
+  schema: JSON.stringify(schemaWithDefinitions),
+  uiSchema: '',
+  onChange: (newSchema, newUiSchema) => mockEvent(newSchema, newUiSchema),
+};
+
 describe('FormBuilder', () => {
   it('renders without error', () => {
     const div = document.createElement('div');
@@ -87,6 +109,7 @@ describe('FormBuilder', () => {
       'Property Parameter: badSideProp in obj2',
     ]);
   });
+
   it('renders the cards in the correct order according to ui:order', () => {
     const modProps = {
       ...props,
@@ -174,5 +197,19 @@ describe('FormBuilder', () => {
     );
     expect(wrapper.exists('.form-body')).toBeTruthy();
     expect(wrapper.exists('[data-test="form-head"]')).toBeFalsy();
+  });
+
+  it('renders $refs with custom titles and descriptions', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const wrapper = mount(<FormBuilder {...propsWithDefinitions} />, {
+      attachTo: div,
+    });
+
+    expect(wrapper.exists('.form-body')).toBeTruthy();
+
+    const cardInputs = wrapper.find('.card-container').first().find('input');
+    expect(cardInputs.at(1).props().value).toEqual('Custom Title');
+    expect(cardInputs.at(2).props().value).toEqual('Custom Description');
   });
 });

--- a/src/formBuilder/defaults/defaultInputs.js
+++ b/src/formBuilder/defaults/defaultInputs.js
@@ -237,6 +237,8 @@ const defaultInputs = {
     ],
     defaultDataSchema: {
       $ref: '',
+      title: '',
+      description: '',
     },
     defaultUiSchema: {},
     type: null,

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -461,8 +461,8 @@ export function generateElementPropsFromSchemas(parameters: {
         definitionData[pathArr[2]]
       ) {
         elementDetails = {
-          ...elementDetails,
           ...definitionData[pathArr[2]],
+          ...elementDetails,
         };
       }
 

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -673,6 +673,8 @@ function generateSchemaElementFromElement(element: ElementProps) {
   if (element.$ref !== undefined) {
     return {
       $ref: element.$ref,
+      title: element.dataOptions.title,
+      description: element.dataOptions.description,
     };
   } else if (element.propType === 'card') {
     if (element.dataOptions.category === 'section') {


### PR DESCRIPTION
Since https://github.com/rjsf-team/react-jsonschema-form/pull/179, react-jsonschema-form supports defining local title and description for a `$ref`, which takes precedent over the definition's title and description.

This PR adds support for this.

In other words, allows you to build a form like this:

```json
{
  "type": "object",
  "definitions": { "address": { "type": "string", "title": "Address" } },
  "properties": {
    "physicalAddress": {
      "$ref": "#/definitions/address",
      "title": "Physical address"
    },
    "mailingAddress": {
      "$ref": "#/definitions/address",
      "title": "Mailing address",
      "description": "if different from physical address"
    }
  },
  "required": ["physicalAddress"],
  "dependencies": {}
}

```