### PR TITLE
Allows definitions with objects

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -3,9 +3,7 @@ import PlaygroundContainer from './PlaygroundContainer';
 
 function App() {
   return (
-    <body>
-      <PlaygroundContainer title='React JSON Schema Form Builder' />
-    </body>
+    <PlaygroundContainer title='React JSON Schema Form Builder' />
   );
 }
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PlaygroundContainer from './PlaygroundContainer';
 
 function App() {
-  return (
-    <PlaygroundContainer title='React JSON Schema Form Builder' />
-  );
+  return <PlaygroundContainer title='React JSON Schema Form Builder' />;
 }
 
 export default App;

--- a/example/src/PlaygroundContainer.js
+++ b/example/src/PlaygroundContainer.js
@@ -18,8 +18,22 @@ const useStyles = createUseStyles({
   },
 });
 
+const jsonSchema = {
+  type: 'object',
+  definitions: {
+    address: {
+      title: 'Address',
+      type: 'object',
+      properties: {
+        lineOne: { type: 'string' },
+        lineTwo: { type: 'string' }
+      }
+    },
+  },
+};
+
 export default function PlaygroundContainer({ title }: { title: string }) {
-  const [schema, setSchema] = React.useState('{}');
+  const [schema, setSchema] = React.useState(JSON.stringify(jsonSchema));
   const [uischema, setUischema] = React.useState('{}');
   const classes = useStyles();
   return (

--- a/example/src/PlaygroundContainer.js
+++ b/example/src/PlaygroundContainer.js
@@ -18,22 +18,8 @@ const useStyles = createUseStyles({
   },
 });
 
-const jsonSchema = {
-  type: 'object',
-  definitions: {
-    address: {
-      title: 'Address',
-      type: 'object',
-      properties: {
-        lineOne: { type: 'string' },
-        lineTwo: { type: 'string' }
-      }
-    },
-  },
-};
-
 export default function PlaygroundContainer({ title }: { title: string }) {
-  const [schema, setSchema] = React.useState(JSON.stringify(jsonSchema));
+  const [schema, setSchema] = React.useState('{}');
   const [uischema, setUischema] = React.useState('{}');
   const classes = useStyles();
   return (

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -476,6 +476,7 @@ export function generateElementPropsFromSchemas(parameters: {
     newElement.name = parameter;
     newElement.required = requiredNames.includes(parameter);
     newElement.$ref = elementDetails.$ref;
+    newElement.dataOptions = elementDetails;
 
     if (elementDetails.type && elementDetails.type === 'object') {
       // create a section
@@ -484,7 +485,6 @@ export function generateElementPropsFromSchemas(parameters: {
       newElement.propType = 'section';
     } else {
       // create a card
-      newElement.dataOptions = elementDetails;
       newElement.uiOptions = uischema[parameter] || {};
 
       // ensure that uiOptions does not have duplicate keys with dataOptions


### PR DESCRIPTION
### Background:

Definitions that were `type: "object"` caused the following error:

![error](https://user-images.githubusercontent.com/728866/115568531-ad4d2e80-a2bc-11eb-837b-87e1568b5b11.png)

Example:

```js
const jsonSchema = {
  type: 'object',
  definitions: {
    address: {
      title: 'Address',
      type: 'object',
      properties: {
        country: { title: 'Country', type: 'string' },
        addressLineOne: { title: 'Address line one', type: 'string' },
      },
    },
  },
}
```

### Cause:

The root cause of the issue was that `dataOptions` was being lost for things deemed "sections".

### Fix:

Assign `dataOptions` for both "sections" and "cards"


