### PR TITLE
Support schema and meta keywords

### DIFF
--- a/src/formBuilder/FormBuilder.test.js
+++ b/src/formBuilder/FormBuilder.test.js
@@ -236,4 +236,31 @@ describe('FormBuilder', () => {
       .map((error) => error.text());
     expect(errors).toEqual([]);
   });
+
+  it('supports the meta keyword and there is no error', () => {
+    const jsonSchema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      meta: {
+        some: 'meta information',
+      },
+    };
+
+    const props = {
+      schema: JSON.stringify(jsonSchema),
+      uiSchema: '{}',
+      onChange: jest.fn(() => {}),
+      mods: {},
+      className: 'my-form-builder',
+    };
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const wrapper = mount(<FormBuilder {...props} />, { attachTo: div });
+    const errors = wrapper
+      .find('.alert-warning')
+      .first()
+      .find('li')
+      .map((error) => error.text());
+    expect(errors).toEqual([]);
+  });
 });

--- a/src/formBuilder/FormBuilder.test.js
+++ b/src/formBuilder/FormBuilder.test.js
@@ -212,4 +212,28 @@ describe('FormBuilder', () => {
     expect(cardInputs.at(1).props().value).toEqual('Custom Title');
     expect(cardInputs.at(2).props().value).toEqual('Custom Description');
   });
+
+  it('supports the $schema keyword and there is no error', () => {
+    const jsonSchema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+    };
+
+    const props = {
+      schema: JSON.stringify(jsonSchema),
+      uiSchema: '{}',
+      onChange: jest.fn(() => {}),
+      mods: {},
+      className: 'my-form-builder',
+    };
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const wrapper = mount(<FormBuilder {...props} />, { attachTo: div });
+    const errors = wrapper
+      .find('.alert-warning')
+      .first()
+      .find('li')
+      .map((error) => error.text());
+    expect(errors).toEqual([]);
+  });
 });

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -131,6 +131,7 @@ const supportedPropertyParameters = new Set([
   'dependencies',
   '$id',
   '$schema',
+  'meta',
 ]);
 
 const supportedUiParameters = new Set([

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -130,6 +130,7 @@ const supportedPropertyParameters = new Set([
   'enumNames',
   'dependencies',
   '$id',
+  '$schema',
 ]);
 
 const supportedUiParameters = new Set([

--- a/src/formBuilder/utils.test.js
+++ b/src/formBuilder/utils.test.js
@@ -76,8 +76,8 @@ describe('parse', () => {
         `
     {
       "key": {
-        "array": ["item1", "item2"], 
-        "name": "obj1", 
+        "array": ["item1", "item2"],
+        "name": "obj1",
         "num": 0
       }
     }`,
@@ -231,6 +231,24 @@ describe('checkForUnsupportedFeatures', () => {
     testUischema = {
       'ui:order': ['obj1', 'obj2'],
     };
+    expect(
+      checkForUnsupportedFeatures(
+        testSchema,
+        testUischema,
+        DEFAULT_FORM_INPUTS,
+      ),
+    ).toEqual([]);
+  });
+
+  it('gives no warnings for the inclusion of $schema and meta keywords', () => {
+    let testSchema = {
+      type: 'object',
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      meta: {
+        some: 'meta information',
+      },
+    };
+    let testUischema = {};
     expect(
       checkForUnsupportedFeatures(
         testSchema,


### PR DESCRIPTION
Currently, the `$schema` keyword was not supported.  This adds support for it.  Also adds support for a `meta` keyword