### PR TITLE
Handle unnamed properties with more than 1 digit

### DIFF
--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -870,7 +870,7 @@ export function updateSchemas(
 export const DEFAULT_INPUT_NAME = 'newInput';
 
 // ensure that each added block has a unique name
-function getIdFromElementsBlock(elements: Array<string>) {
+function getIdFromElementsBlock(elements: Array<ElementProps>) {
   const names = elements.map((element) => element.name);
   const defaultNameLength = DEFAULT_INPUT_NAME.length;
 

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -867,6 +867,8 @@ export function updateSchemas(
   onChange(newSchema, newUiSchema);
 }
 
+export const DEFAULT_INPUT_NAME = 'newInput';
+
 // given an initial schema, update with a new card appended
 export function addCardObj(parameters: {
   schema: { [string]: any },

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -869,6 +869,21 @@ export function updateSchemas(
 
 export const DEFAULT_INPUT_NAME = 'newInput';
 
+// ensure that each added block has a unique name
+function getIdFromElementsBlock(elements: Array<string>) {
+  const names = elements.map((element) => element.name);
+
+  return names.length > 0
+    ? Math.max(
+        ...names.map((name) =>
+          name.startsWith(DEFAULT_INPUT_NAME)
+            ? Number.parseInt(name.charAt(8), 10)
+            : 0,
+        ),
+      ) + 1
+    : 1;
+}
+
 // given an initial schema, update with a new card appended
 export function addCardObj(parameters: {
   schema: { [string]: any },
@@ -898,24 +913,11 @@ export function addCardObj(parameters: {
     categoryHash,
   });
 
-  // ensure that each added block has a unique name
-
-  const names = newElementObjArr.map((element) => element.name);
-  const i =
-    names.length > 0
-      ? Math.max(
-          ...names.map((name) =>
-            name.startsWith('newInput')
-              ? Number.parseInt(name.charAt(8), 10)
-              : 0,
-          ),
-        ) + 1
-      : 1;
-
+  const i = getIdFromElementsBlock(newElementObjArr);
   const dataOptions = getNewElementDefaultDataOptions(i, mods);
 
   const newElement = ({
-    name: `newInput${i}`,
+    name: `${DEFAULT_INPUT_NAME}${i}`,
     required: false,
     dataOptions: dataOptions,
     uiOptions: (mods && mods.newElementDefaultUiSchema) || {},
@@ -966,21 +968,10 @@ export function addSectionObj(parameters: {
     categoryHash,
   });
 
-  // ensure that each added block has a unique name
-  const names = newElementObjArr.map((element) => element.name);
-  const i =
-    names.length > 0
-      ? Math.max(
-          ...names.map((name) =>
-            name.startsWith('newInput')
-              ? Number.parseInt(name.charAt(8), 10)
-              : 0,
-          ),
-        ) + 1
-      : 1;
+  const i = getIdFromElementsBlock(newElementObjArr);
 
   const newElement = ({
-    name: `newInput${i}`,
+    name: `${DEFAULT_INPUT_NAME}${i}`,
     required: false,
     dataOptions: {
       title: `New Input ${i}`,

--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -872,14 +872,22 @@ export const DEFAULT_INPUT_NAME = 'newInput';
 // ensure that each added block has a unique name
 function getIdFromElementsBlock(elements: Array<string>) {
   const names = elements.map((element) => element.name);
+  const defaultNameLength = DEFAULT_INPUT_NAME.length;
 
   return names.length > 0
     ? Math.max(
-        ...names.map((name) =>
-          name.startsWith(DEFAULT_INPUT_NAME)
-            ? Number.parseInt(name.charAt(8), 10)
-            : 0,
-        ),
+        ...names.map((name) => {
+          if (name.startsWith(DEFAULT_INPUT_NAME)) {
+            const index = name.substring(defaultNameLength, name.length);
+            const value = Number.parseInt(index);
+
+            if (!isNaN(value)) {
+              return value;
+            }
+          }
+
+          return 0;
+        }),
       ) + 1
     : 1;
 }

--- a/src/formBuilder/utils.test.js
+++ b/src/formBuilder/utils.test.js
@@ -17,7 +17,7 @@ import {
   getNewElementDefaultDataOptions,
   addCardObj,
   addSectionObj,
-  DEFAULT_INPUT_NAME
+  DEFAULT_INPUT_NAME,
 } from './utils';
 import DEFAULT_FORM_INPUTS from './defaults/defaultFormInputs';
 
@@ -85,7 +85,7 @@ function generateSchemaWithUnnamedProperties(amount: number) {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Test',
     type: 'object',
-    properties: properties
+    properties: properties,
   };
 }
 
@@ -731,7 +731,7 @@ describe('getNewElementDefaultDataOptions', () => {
 
 describe('addCardObj', () => {
   it('should be able to add more than 10 unnamed CardObj', () => {
-    const mockEvent = jest.fn(() => { });
+    const mockEvent = jest.fn(() => {});
     const defaultUiSchema = {};
     const props = {
       schema: generateSchemaWithUnnamedProperties(10),
@@ -739,7 +739,7 @@ describe('addCardObj', () => {
       onChange: (schema, uischema) => mockEvent(schema, uischema),
       definitionData: {},
       definitionUi: {},
-      categoryHash: {}
+      categoryHash: {},
     };
 
     addCardObj(props);
@@ -747,13 +747,13 @@ describe('addCardObj', () => {
     const currentSchema = mockEvent.mock.calls[0][0];
     const inputElementsCount = Object.keys(currentSchema.properties).length;
 
-    expect(inputElementsCount).toEqual(11)
+    expect(inputElementsCount).toEqual(11);
   });
 });
 
 describe('addSectionObj', () => {
   it('should be able to add more than 10 unnamed SectionObj', () => {
-    const mockEvent = jest.fn(() => { });
+    const mockEvent = jest.fn(() => {});
     const defaultUiSchema = {};
     const props = {
       schema: generateSchemaWithUnnamedProperties(10),
@@ -761,7 +761,7 @@ describe('addSectionObj', () => {
       onChange: (schema, uischema) => mockEvent(schema, uischema),
       definitionData: {},
       definitionUi: {},
-      categoryHash: {}
+      categoryHash: {},
     };
 
     addSectionObj(props);
@@ -769,6 +769,6 @@ describe('addSectionObj', () => {
     const currentSchema = mockEvent.mock.calls[0][0];
     const inputElementsCount = Object.keys(currentSchema.properties).length;
 
-    expect(inputElementsCount).toEqual(11)
+    expect(inputElementsCount).toEqual(11);
   });
 });

--- a/src/formBuilder/utils.test.js
+++ b/src/formBuilder/utils.test.js
@@ -15,6 +15,9 @@ import {
   subtractArray,
   excludeKeys,
   getNewElementDefaultDataOptions,
+  addCardObj,
+  addSectionObj,
+  DEFAULT_INPUT_NAME
 } from './utils';
 import DEFAULT_FORM_INPUTS from './defaults/defaultFormInputs';
 
@@ -71,6 +74,20 @@ const elementPropArr = [
     propType: 'card',
   },
 ];
+
+function generateSchemaWithUnnamedProperties(amount: number) {
+  const properties = [...Array(10).keys()].reduce((acc, id) => {
+    return { ...acc, [`${DEFAULT_INPUT_NAME}${id + 1}`]: { type: 'string' } };
+  }, {});
+
+  return {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    title: 'Test',
+    type: 'object',
+    properties: properties
+  };
+}
 
 describe('parse', () => {
   it('parses valid JSON into a JS object', () => {
@@ -709,5 +726,49 @@ describe('getNewElementDefaultDataOptions', () => {
     const actualDataOptions = getNewElementDefaultDataOptions(i, mods);
 
     expect(actualDataOptions).toEqual(expectedDataOptions);
+  });
+});
+
+describe('addCardObj', () => {
+  it('should be able to add more than 10 unnamed CardObj', () => {
+    const mockEvent = jest.fn(() => { });
+    const defaultUiSchema = {};
+    const props = {
+      schema: generateSchemaWithUnnamedProperties(10),
+      uischema: defaultUiSchema,
+      onChange: (schema, uischema) => mockEvent(schema, uischema),
+      definitionData: {},
+      definitionUi: {},
+      categoryHash: {}
+    };
+
+    addCardObj(props);
+
+    const currentSchema = mockEvent.mock.calls[0][0];
+    const inputElementsCount = Object.keys(currentSchema.properties).length;
+
+    expect(inputElementsCount).toEqual(11)
+  });
+});
+
+describe('addSectionObj', () => {
+  it('should be able to add more than 10 unnamed SectionObj', () => {
+    const mockEvent = jest.fn(() => { });
+    const defaultUiSchema = {};
+    const props = {
+      schema: generateSchemaWithUnnamedProperties(10),
+      uischema: defaultUiSchema,
+      onChange: (schema, uischema) => mockEvent(schema, uischema),
+      definitionData: {},
+      definitionUi: {},
+      categoryHash: {}
+    };
+
+    addSectionObj(props);
+
+    const currentSchema = mockEvent.mock.calls[0][0];
+    const inputElementsCount = Object.keys(currentSchema.properties).length;
+
+    expect(inputElementsCount).toEqual(11)
   });
 });

--- a/src/formBuilder/utils.test.js
+++ b/src/formBuilder/utils.test.js
@@ -75,7 +75,7 @@ const elementPropArr = [
   },
 ];
 
-function generateSchemaWithUnnamedProperties(amount: number) {
+function generateSchemaWithUnnamedProperties(amount) {
   const properties = [...Array(10).keys()].reduce((acc, id) => {
     return { ...acc, [`${DEFAULT_INPUT_NAME}${id + 1}`]: { type: 'string' } };
   }, {});


### PR DESCRIPTION
I realized the current code is assuming unnamed properties won't include two digits but, there is nothing preventing it. So, if you add more than 9 unnamed elements, the greater id is not obtained properly. As a result, the autogenerated id is duplicated. 

Since this id is also used by React to key each element, React is throwing an exception because of duplicated id.

I guess this could be related with https://github.com/ginkgobioworks/react-json-schema-form-builder/issues/115 and maybe with https://github.com/ginkgobioworks/react-json-schema-form-builder/issues/113.