### PR TITLE
Fix: #285 Cannot open certain element without opening all of them one by one

### DIFF
--- a/src/formBuilder/utils.js
+++ b/src/formBuilder/utils.js
@@ -1103,6 +1103,14 @@ export function generateElementComponentsFromSchemas(parameters: {
   });
 
   const elementList = elementPropArr.map((elementProp, index) => {
+    const MIN_CARD_OPEN_ARRAY_LENGTH = index + 1;
+    const currentLength = cardOpenArray.length;
+
+    if (currentLength < MIN_CARD_OPEN_ARRAY_LENGTH) {
+      cardOpenArray.push(
+        ...new Array(MIN_CARD_OPEN_ARRAY_LENGTH - currentLength).fill(false),
+      );
+    }
     const expanded =
       (cardOpenArray && index < cardOpenArray.length && cardOpenArray[index]) ||
       false;


### PR DESCRIPTION
In src/formBuilder/utils.js

const expanded is calculated like this:

const expanded =
      (cardOpenArray && index < cardOpenArray.length && cardOpenArray[index]) ||
      false;
If we fetch schema and populate Items cardOpenArray will always be empty, so when you click at expend it will start pushing boolean values to cardOpenArray for every click [false] then another click [false,false] etc.

i fixed this adding:

if (cardOpenArray.length - 1 < index){
      for (let i = 1; i <= index+1; i++) {
        cardOpenArray.push(false);
      }
    }
So it will populate initial state for array.

Changes made:
Extracted the minimum required length of cardOpenArray as a constant to make it clearer what the code is doing.

Renamed the variable i to a more descriptive name currentLength.

Instead of using a for loop to push false values into the cardOpenArray, used the fill method on a new array and spread it into the existing array. 