### PR TITLE
[Bug] Do not start a drag when a gesture begins in an interactive element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Dragging no longer starts when a pointer or keyboard gesture begins inside an interactive element of a form element card. Text in a card's inputs can be selected with the mouse again, `Space` and `Enter` type and activate normally instead of starting a keyboard drag, and cards are still draggable everywhere else. (See [issue #685](https://github.com/ginkgobioworks/react-json-schema-form-builder/issues/685).)
+
 ## [4.1.0] - 2026-01-03
 
 ### Fixed

--- a/src/formBuilder/FormBuilder.test.tsx
+++ b/src/formBuilder/FormBuilder.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  createEvent,
+  within,
+} from '@testing-library/react';
 import FormBuilder from './FormBuilder';
 
 // mocks to record events
@@ -641,5 +647,56 @@ describe('FormBuilder', () => {
 
     expect(JSON.parse(uiSchemaString)).toEqual(expected);
     mockEvent.mockClear();
+  });
+});
+
+describe('FormBuilder drag activation', () => {
+  const singleFieldProps = {
+    ...props,
+    schema: JSON.stringify({
+      type: 'object',
+      properties: {
+        obj1: {
+          type: 'string',
+          title: 'Heat',
+        },
+      },
+    }),
+  };
+
+  const getSortableItem = () =>
+    screen
+      .getByTestId('card-container')
+      .closest('[aria-roledescription="sortable"]')!;
+
+  it('does not start a keyboard drag from a card text input', () => {
+    render(<FormBuilder {...singleFieldProps} />);
+    fireEvent.click(screen.getByTestId('ChevronRightIcon'));
+
+    const titleInput = within(
+      screen.getByTestId('card-container'),
+    ).getByPlaceholderText('Title');
+    const keyDown = createEvent.keyDown(titleInput, {
+      code: 'Space',
+      key: ' ',
+    });
+    fireEvent(titleInput, keyDown);
+
+    // The space has to reach the input rather than being swallowed to start a
+    // keyboard drag of the card.
+    expect(keyDown.defaultPrevented).toBe(false);
+  });
+
+  it('starts a keyboard drag from the card itself', () => {
+    render(<FormBuilder {...singleFieldProps} />);
+
+    const sortableItem = getSortableItem();
+    const keyDown = createEvent.keyDown(sortableItem, {
+      code: 'Space',
+      key: ' ',
+    });
+    fireEvent(sortableItem, keyDown);
+
+    expect(keyDown.defaultPrevented).toBe(true);
   });
 });

--- a/src/formBuilder/FormBuilder.tsx
+++ b/src/formBuilder/FormBuilder.tsx
@@ -10,8 +10,6 @@ import React, {
 import {
   DndContext,
   closestCenter,
-  KeyboardSensor,
-  PointerSensor,
   useSensor,
   useSensors,
   DragEndEvent,
@@ -44,6 +42,7 @@ import {
   excludeKeys,
 } from './utils';
 import SortableItem from './SortableItem';
+import { FormBuilderKeyboardSensor, FormBuilderPointerSensor } from './sensors';
 import DEFAULT_FORM_INPUTS from './defaults/defaultFormInputs';
 import type {
   Mods,
@@ -157,12 +156,12 @@ function FormBuilder({
   );
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(FormBuilderPointerSensor, {
       activationConstraint: {
         distance: 8, // Require 8px movement before drag starts (allows clicks)
       },
     }),
-    useSensor(KeyboardSensor, {
+    useSensor(FormBuilderKeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
   );

--- a/src/formBuilder/Section.tsx
+++ b/src/formBuilder/Section.tsx
@@ -8,8 +8,6 @@ import React, {
 import {
   DndContext,
   closestCenter,
-  KeyboardSensor,
-  PointerSensor,
   useSensor,
   useSensors,
   DragEndEvent,
@@ -50,6 +48,7 @@ import {
   handleDndDragEnd,
 } from './utils';
 import SortableItem from './SortableItem';
+import { FormBuilderKeyboardSensor, FormBuilderPointerSensor } from './sensors';
 import type { SectionProps, JsonSchema } from './types';
 
 function Section({
@@ -130,12 +129,12 @@ function Section({
   );
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(FormBuilderPointerSensor, {
       activationConstraint: {
         distance: 8, // Require 8px movement before drag starts (allows clicks)
       },
     }),
-    useSensor(KeyboardSensor, {
+    useSensor(FormBuilderKeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
   );

--- a/src/formBuilder/sensors.test.tsx
+++ b/src/formBuilder/sensors.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FormBuilderKeyboardSensor, FormBuilderPointerSensor } from './sensors';
+import type {
+  KeyboardSensorOptions,
+  PointerSensorOptions,
+} from '@dnd-kit/core';
+
+const [pointerActivator] = FormBuilderPointerSensor.activators;
+const [keyboardActivator] = FormBuilderKeyboardSensor.activators;
+
+function activatePointer(
+  target: Element,
+  nativeEvent: Partial<PointerEvent> = {},
+) {
+  const event = {
+    target,
+    nativeEvent: { target, isPrimary: true, button: 0, ...nativeEvent },
+  };
+  return pointerActivator.handler(
+    event as unknown as React.PointerEvent,
+    {} as PointerSensorOptions,
+  );
+}
+
+function activateKeyboard(target: Element, code: string) {
+  const event = {
+    target,
+    nativeEvent: { target, code },
+    preventDefault: jest.fn(),
+  };
+  const activated = keyboardActivator.handler(
+    event as unknown as React.KeyboardEvent,
+    {} as KeyboardSensorOptions,
+    { active: { activatorNode: { current: null } } } as unknown as Parameters<
+      typeof keyboardActivator.handler
+    >[2],
+  );
+  return { activated, preventDefault: event.preventDefault };
+}
+
+describe('form builder sensors', () => {
+  beforeEach(() => {
+    render(
+      <div data-testid='draggable'>
+        <input placeholder='Title' />
+        <textarea placeholder='Description' />
+        <button type='button'>
+          <span data-testid='icon' />
+        </button>
+        <span data-testid='label'>Not interactive</span>
+      </div>,
+    );
+  });
+
+  describe('FormBuilderPointerSensor', () => {
+    it('does not activate on a press inside a text field', () => {
+      expect(activatePointer(screen.getByPlaceholderText('Title'))).toBe(false);
+      expect(activatePointer(screen.getByPlaceholderText('Description'))).toBe(
+        false,
+      );
+    });
+
+    it('does not activate on a press inside a button', () => {
+      expect(activatePointer(screen.getByRole('button'))).toBe(false);
+      expect(activatePointer(screen.getByTestId('icon'))).toBe(false);
+    });
+
+    it('activates on a press outside of an interactive element', () => {
+      expect(activatePointer(screen.getByTestId('draggable'))).toBe(true);
+      expect(activatePointer(screen.getByTestId('label'))).toBe(true);
+    });
+
+    it('still ignores secondary and non-primary pointers', () => {
+      const target = screen.getByTestId('draggable');
+      expect(activatePointer(target, { button: 2 })).toBe(false);
+      expect(activatePointer(target, { isPrimary: false })).toBe(false);
+    });
+  });
+
+  describe('FormBuilderKeyboardSensor', () => {
+    it('does not activate on Space inside a text field', () => {
+      const { activated, preventDefault } = activateKeyboard(
+        screen.getByPlaceholderText('Title'),
+        'Space',
+      );
+      expect(activated).toBe(false);
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('does not activate on Space inside a button', () => {
+      const { activated, preventDefault } = activateKeyboard(
+        screen.getByRole('button'),
+        'Space',
+      );
+      expect(activated).toBe(false);
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('activates on Space outside of an interactive element', () => {
+      const { activated, preventDefault } = activateKeyboard(
+        screen.getByTestId('draggable'),
+        'Space',
+      );
+      expect(activated).toBe(true);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('ignores keys that do not start a drag', () => {
+      const { activated } = activateKeyboard(
+        screen.getByTestId('draggable'),
+        'KeyA',
+      );
+      expect(activated).toBe(false);
+    });
+  });
+});

--- a/src/formBuilder/sensors.ts
+++ b/src/formBuilder/sensors.ts
@@ -1,0 +1,59 @@
+import { KeyboardSensor, PointerSensor } from '@dnd-kit/core';
+import type {
+  Activators,
+  KeyboardSensorOptions,
+  PointerSensorOptions,
+} from '@dnd-kit/core';
+import type { KeyboardEvent, PointerEvent } from 'react';
+
+// Elements whose own pointer and keyboard gestures must win over dragging.
+const INTERACTIVE_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  'option',
+  'button',
+  'a[href]',
+  '[contenteditable]:not([contenteditable="false"])',
+].join(',');
+
+function startsInInteractiveElement(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element && target.closest(INTERACTIVE_SELECTOR) !== null
+  );
+}
+
+const [pointerActivator] = PointerSensor.activators;
+const [keyboardActivator] = KeyboardSensor.activators;
+
+/**
+ * A `PointerSensor` that does not start a drag when the gesture begins inside
+ * an interactive element, so that pressing and dragging within a text field
+ * selects text instead of dragging the enclosing form element card.
+ */
+export class FormBuilderPointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: pointerActivator.eventName,
+      handler: (event: PointerEvent, options: PointerSensorOptions) =>
+        !startsInInteractiveElement(event.nativeEvent.target) &&
+        pointerActivator.handler(event, options),
+    },
+  ];
+}
+
+/**
+ * A `KeyboardSensor` that ignores its activation keys when they are pressed
+ * inside an interactive element, so that typing a space in a text field, or
+ * activating a button with Space or Enter, does not start a keyboard drag.
+ */
+export class FormBuilderKeyboardSensor extends KeyboardSensor {
+  static activators: Activators<KeyboardSensorOptions> = [
+    {
+      eventName: keyboardActivator.eventName,
+      handler: (event: KeyboardEvent, options, context) =>
+        !startsInInteractiveElement(event.nativeEvent.target) &&
+        keyboardActivator.handler(event, options, context),
+    },
+  ];
+}


### PR DESCRIPTION
Fixes #685.

## The problem

Since the move to `@dnd-kit` in 4.0.0, the drag sensors intercept gestures that belong to the controls inside a form element card:

**Keyboard** — pressing <kbd>Space</kbd> in any of a card's inputs starts a keyboard drag instead of typing a space. This is #685, and it is reproducible on the [playground](https://ginkgobioworks.github.io/react-json-schema-form-builder/): *Visual form builder* → *Add Field* → expand the card → press <kbd>Space</kbd> in **Display Name**. The same applies to <kbd>Enter</kbd>, and to <kbd>Space</kbd> on a focused button inside a card (the up/down/edit/delete icons), which starts a drag rather than activating the button.

**Mouse** — pressing inside a card's text field and dragging cannot select text: the selection is wiped and the card is dragged instead. Same repro, but drag across the text in **Display Name**.

## Root cause

`SortableItem` spreads `attributes` and `listeners` over the whole sortable item and never calls `setActivatorNodeRef`, so every `pointerdown`/`keydown` anywhere inside a card reaches the sensors and there is no activator node:

https://github.com/ginkgobioworks/react-json-schema-form-builder/blob/v4.1.0/src/formBuilder/SortableItem.tsx#L29-L33

From there, in `@dnd-kit/core@6.3.1`:

- `PointerSensor.activators` only rejects non-primary and non-left-button presses, so a press inside a text field starts a pending drag. Once the configured 8px activation distance is travelled, `AbstractPointerSensor.handleStart` calls `removeTextSelection()` and re-runs it on every `selectionchange`, so the selection can never grow and the card drags instead of text being selected.
- `KeyboardSensor.activators` has a guard for exactly this case — `if (activator && event.target !== activator) return false;` — but it is only reachable when an activator node exists. With `active.activatorNode.current === null` the guard is skipped, so a start key is `preventDefault()`ed and begins a keyboard drag no matter what is focused.

## The fix

A small `sensors.ts` module wraps both sensors so their activators bail out when the gesture starts inside an interactive element (`input`, `textarea`, `select`, `option`, `button`, `a[href]`, `contenteditable`), delegating to the original activator otherwise. `FormBuilder` and `Section` use the wrapped sensors.

This keeps the sensors' own semantics (non-primary/right-button presses are still rejected, non-start keys are still ignored) and does not touch the card layout, so it needs no drag handle and no visual change. Dragging a card from anywhere else — its header, its title area, its body — behaves exactly as before, with mouse and keyboard.

One intentional behaviour change beyond the bug: a drag no longer *starts* from a press on a button inside a card. That is required for the keyboard half (Space must activate a focused button, not begin a drag), and it seemed better to keep pointer and keyboard consistent rather than let a press-and-drag on the delete icon move the card. Happy to narrow the selector to text-entry elements only if you would rather keep that.

An alternative fix is to give each card a real drag handle and wire `setActivatorNodeRef` to it, which would make `@dnd-kit`'s own keyboard guard effective. That changes the card layout and how users drag, so it seemed like your call rather than something to slip into a bug fix.

## Tests

- `src/formBuilder/sensors.test.tsx` — both activators, for text fields, buttons, nested children of a button, and non-interactive targets, plus the preserved non-primary/right-button and non-start-key behaviour.
- `src/formBuilder/FormBuilder.test.tsx` — a regression test that <kbd>Space</kbd> in a card's Display Name is not `preventDefault()`ed (this fails on `main`), and a companion test that <kbd>Space</kbd> on the sortable item itself still starts a keyboard drag.

`npm test` passes in full (209 tests, prettier, eslint, tsc); `sensors.ts` is at 100% coverage.
